### PR TITLE
Add reusable_window_ids option

### DIFF
--- a/doc/cmdbuf.nvim.txt
+++ b/doc/cmdbuf.nvim.txt
@@ -48,6 +48,7 @@ OPTIONS                                                  *cmdbuf.nvim-OPTIONS*
 
 - {column} (number | nil): initial cursor column in the buffer.
 - {line} (number | nil): set this string to the bottom line in the buffer.
+- {reusable_window_ids} (list | nil): force to reuse window id that has the same buffer name. (default: {})
 - {type} (string | nil): handler type (default = "vim/cmd")
   - `vim/cmd`: |q:| alternative
   - `vim/sesarch/forward`: |q/| alternative

--- a/lua/cmdbuf/command.lua
+++ b/lua/cmdbuf/command.lua
@@ -13,7 +13,7 @@ function ShowError.open(layout_opts, opts)
   end
 
   local buffer, created = require("cmdbuf.core.buffer").get_or_create(handler, opts.line)
-  local layout = require("cmdbuf.layout").new(layout_opts)
+  local layout = require("cmdbuf.layout").new(layout_opts, opts.reusable_window_ids or {})
   Window.open(buffer, created, layout, opts.line, opts.column)
 end
 

--- a/lua/cmdbuf/core/buffer.lua
+++ b/lua/cmdbuf/core/buffer.lua
@@ -103,6 +103,10 @@ function Buffer.set_to(self, window_id)
   vim.api.nvim_win_set_buf(window_id, self._bufnr)
 end
 
+function Buffer.name(self)
+  return vim.api.nvim_buf_get_name(self._bufnr)
+end
+
 function Buffer.cleanup(self)
   _buffers[self._bufnr] = nil
 end

--- a/lua/cmdbuf/core/window.lua
+++ b/lua/cmdbuf/core/window.lua
@@ -8,7 +8,10 @@ Window.__index = Window
 
 function Window.open(buffer, created, layout, line, column)
   local origin_window_id = vim.api.nvim_get_current_win()
-  local window_id = layout:open()
+
+  local buffer_name = buffer:name()
+  local window_id = layout:open(buffer_name)
+
   buffer:set_to(window_id)
   _windows[window_id] = origin_window_id
 

--- a/lua/cmdbuf/layout.lua
+++ b/lua/cmdbuf/layout.lua
@@ -31,7 +31,7 @@ end
 local Layout = {}
 Layout.__index = Layout
 
-function Layout.new(opts)
+function Layout.new(opts, reusable_window_ids)
   opts = opts or {}
   local typ = opts.type
 
@@ -48,11 +48,20 @@ function Layout.new(opts)
     error("unexpected layout type: " .. typ)
   end
 
-  local tbl = { _f = f }
+  local tbl = { _f = f, _reusable_window_ids = reusable_window_ids }
   return setmetatable(tbl, Layout)
 end
 
-function Layout.open(self)
+function Layout.open(self, buffer_name)
+  for _, window_id in ipairs(self._reusable_window_ids) do
+    local bufnr = vim.api.nvim_win_get_buf(window_id)
+    local name = vim.api.nvim_buf_get_name(bufnr)
+    if name == buffer_name then
+      vim.api.nvim_set_current_win(window_id)
+      return window_id
+    end
+  end
+
   self._f()
   return vim.api.nvim_get_current_win()
 end

--- a/spec/lua/cmdbuf/doc.lua
+++ b/spec/lua/cmdbuf/doc.lua
@@ -26,6 +26,7 @@ require("genvdoc").generate(plugin_name .. ".nvim", {
           local descriptions = {
             line = [[(number | nil): set this string to the bottom line in the buffer.]],
             column = [[(number | nil): initial cursor column in the buffer.]],
+            reusable_window_ids = [[(list | nil): force to reuse the window that has the same buffer name. (default: {})]],
             type = [[(string | nil): handler type (default = "vim/cmd")
   - `vim/cmd`: |q:| alternative
   - `vim/sesarch/forward`: |q/| alternative

--- a/spec/lua/cmdbuf/init_spec.lua
+++ b/spec/lua/cmdbuf/init_spec.lua
@@ -223,4 +223,25 @@ history2]])
     cmdbuf.execute({ quit = true })
     assert.window(second_restored_win)
   end)
+
+  it("can reuse the same type window", function()
+    vim.cmd.vsplit()
+
+    cmdbuf.split_open()
+    local window_id = vim.api.nvim_get_current_win()
+
+    vim.cmd.wincmd("w")
+
+    cmdbuf.open({ reusable_window_ids = vim.api.nvim_tabpage_list_wins(0) })
+
+    assert.window(window_id)
+    assert.buffer("cmdbuf://vim/cmd-buffer")
+  end)
+
+  it("ignores reusable windows when there is no the same type window", function()
+    cmdbuf.split_open(vim.o.cmdwinheight, { reusable_window_ids = vim.api.nvim_tabpage_list_wins(0) })
+
+    assert.window_count(2)
+    assert.buffer("cmdbuf://vim/cmd-buffer")
+  end)
 end)


### PR DESCRIPTION
example

```lua
require("cmdbuf").split_open(
  vim.o.cmdwinheight,
  { reusable_window_ids = vim.api.nvim_tabpage_list_wins(0) }
)
```
