### PR TITLE
support specifying maximum number of histories

### DIFF
--- a/lua/cmdbuf/command.lua
+++ b/lua/cmdbuf/command.lua
@@ -10,7 +10,7 @@ function M.open(opts)
     require("cmdbuf.vendor.misclib.message").error(err)
   end
 
-  local buffer, created = require("cmdbuf.core.buffer").get_or_create(handler, opts.line)
+  local buffer, created = require("cmdbuf.core.buffer").get_or_create(handler, opts.line, opts.n)
   Window.open(buffer, created, opts.open_window, opts.reusable_window_ids, opts.line, opts.column)
 end
 

--- a/lua/cmdbuf/handler/lua/cmd.lua
+++ b/lua/cmdbuf/handler/lua/cmd.lua
@@ -12,7 +12,7 @@ function M._lua(cmd)
   return "lua " .. cmd
 end
 
-function M.histories()
+function M.histories(_, n)
   return historylib.filter_map("cmd", function(cmd)
     do
       local s, e = cmd:find("^%s*lua%s+")
@@ -27,7 +27,7 @@ function M.histories()
       end
     end
     return nil
-  end)
+  end, n)
 end
 
 function M.add_history(self, line)

--- a/lua/cmdbuf/handler/lua/variable/buffer.lua
+++ b/lua/cmdbuf/handler/lua/variable/buffer.lua
@@ -13,7 +13,7 @@ function M._lua(cmd)
   return "lua vim.b." .. cmd
 end
 
-function M.histories(self)
+function M.histories(self, n)
   if not vim.api.nvim_buf_is_valid(self._bufnr) then
     return {}
   end
@@ -29,7 +29,7 @@ function M.histories(self)
       return nil
     end
     return line
-  end)
+  end, n)
 
   local prefix_length = #"b:" + 1
   local keys = vim.api.nvim_buf_call(self._bufnr, function()

--- a/lua/cmdbuf/handler/lua/variable/global.lua
+++ b/lua/cmdbuf/handler/lua/variable/global.lua
@@ -12,7 +12,7 @@ function M._lua(cmd)
   return "lua vim.g." .. cmd
 end
 
-function M.histories(_)
+function M.histories(_, n)
   local cmds = historylib.filter_map("cmd", function(cmd)
     local s, e = cmd:find("^%s*lua%s+vim%.g%.")
     if not s then
@@ -24,7 +24,7 @@ function M.histories(_)
       return nil
     end
     return line
-  end)
+  end, n)
 
   local prefix_length = #"g:" + 1
   local keys = vim.fn.getcompletion("g:*", "var")

--- a/lua/cmdbuf/handler/vim/cmd.lua
+++ b/lua/cmdbuf/handler/vim/cmd.lua
@@ -8,13 +8,13 @@ function M.new()
   return setmetatable({}, M)
 end
 
-function M.histories()
+function M.histories(_, n)
   return historylib.filter_map("cmd", function(cmd)
     if cmd == "" then
       return nil
     end
     return cmd
-  end)
+  end, n)
 end
 
 function M.add_history(_, line)

--- a/lua/cmdbuf/handler/vim/input.lua
+++ b/lua/cmdbuf/handler/vim/input.lua
@@ -7,13 +7,13 @@ function M.new()
   return setmetatable({}, M)
 end
 
-function M.histories()
+function M.histories(_, n)
   return historylib.filter_map("input", function(input)
     if input == "" then
       return nil
     end
     return input
-  end)
+  end, n)
 end
 
 function M.add_history(_, line)

--- a/lua/cmdbuf/handler/vim/search/forward.lua
+++ b/lua/cmdbuf/handler/vim/search/forward.lua
@@ -12,13 +12,13 @@ end
 M.flags = ""
 M.searchforward = 1
 
-function M.histories()
+function M.histories(_, n)
   return historylib.filter_map("search", function(cmd)
     if cmd == "" then
       return nil
     end
     return cmd
-  end)
+  end, n)
 end
 
 function M.add_history(_, line)

--- a/lua/cmdbuf/lib/history.lua
+++ b/lua/cmdbuf/lib/history.lua
@@ -5,15 +5,23 @@ function M.delete(name, str)
   vim.fn.histdel(name, pattern)
 end
 
-function M.filter_map(name, f)
-  vim.validate({ name = { name, "string" }, f = { f, "function" } })
+function M.filter_map(name, f, n)
+  vim.validate({
+    name = { name, "string" },
+    f = { f, "function" },
+    n = { n, function(x) return x == nil or type(x) == "number" end, "number or nil" },
+  })
   local count = vim.fn.histnr(name)
+  n = n or count
   local cmds = {}
-  for i = 1, count, 1 do
+  for i = count, 1, -1 do
     local history = vim.fn.histget(name, i)
     local cmd = f(history)
     if cmd then
-      table.insert(cmds, cmd)
+      table.insert(cmds, 1, cmd)
+    end
+    if #cmds >= n then
+      return cmds
     end
   end
   return cmds

--- a/lua/cmdbuf/option.lua
+++ b/lua/cmdbuf/option.lua
@@ -6,6 +6,7 @@ M.default_open_opts = {
   column = nil,
   reusable_window_ids = {},
   open_window = function() end,
+  n = nil,
 }
 function M.new_open_opts(raw_opts)
   vim.validate({ raw_opts = { raw_opts, "table" } })


### PR DESCRIPTION
Thank you for the nice plugin!!

I open this PR to add the `n` option to limit the number of histories on cmdbuf
because edit can be very slow when treesitter is on and buffer is too large... (5000 lines in my case)



